### PR TITLE
Fix import in hello.go

### DIFF
--- a/gettext/hello.go
+++ b/gettext/hello.go
@@ -9,7 +9,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/chai2010/gettext-go"
+	"github.com/chai2010/gettext-go/gettext"
 )
 
 func main() {


### PR DESCRIPTION
It is improperly importing github.com/chai2010/gettext-go/ instead of
github.com/chai2010/gettext-go/gettext

Before the fix:
$ go build hello.go
hello.go:12:2: no buildable Go source files in
/storage/gopath/src/github.com/chai2010/gettext-go

After the fix:
$ go build hello.go
$ ./hello
你好, 世界!

This is also causing https://github.com/golang/dep/issues/170 since dep
doesn't like importing the parent dir (not sure what's wrong with it
though)